### PR TITLE
dropdown alert style fix

### DIFF
--- a/develop/components/pages/DropdownPage.tsx
+++ b/develop/components/pages/DropdownPage.tsx
@@ -11,7 +11,7 @@ const DropdownPage: React.FunctionComponent = () => {
     const [dropDownList4Selected, setDropdownList4Selected] = React.useState<DropdownItem>(null);
     const [dropDownList5Selected, setDropdownList5Selected] = React.useState<Array<DropdownItem>>([]);
     const [disabled, setDisabled] = React.useState<boolean>(false);
-    const [error, setError] = React.useState<string>(null);
+    const [error, setError] = React.useState<string>("");
 
     const handleToggleError = React.useCallback(() => {
         setError((currentError) => (currentError === null) ? "Example error message" : null);

--- a/develop/components/pages/DropdownPage.tsx
+++ b/develop/components/pages/DropdownPage.tsx
@@ -11,6 +11,11 @@ const DropdownPage: React.FunctionComponent = () => {
     const [dropDownList4Selected, setDropdownList4Selected] = React.useState<DropdownItem>(null);
     const [dropDownList5Selected, setDropdownList5Selected] = React.useState<Array<DropdownItem>>([]);
     const [disabled, setDisabled] = React.useState<boolean>(false);
+    const [error, setError] = React.useState<string>(null);
+
+    const handleToggleError = React.useCallback(() => {
+        setError((currentError) => (currentError === null) ? "Example error message" : null);
+    }, [setError]);
 
     return (
         <div className="route-template container">
@@ -32,6 +37,7 @@ const DropdownPage: React.FunctionComponent = () => {
                             selectedValue={dropDownList1Selected}
                             onChange={(value: DropdownItem) => setDropdownList1Selected(value)}
                             disabled={disabled}
+                            error={error}
                         />
                     </div>
 
@@ -47,6 +53,7 @@ const DropdownPage: React.FunctionComponent = () => {
                             placeholder="Multi option"
                             multi={true}
                             disabled={disabled}
+                            error={error}
                         />
                     </div>
 
@@ -59,6 +66,7 @@ const DropdownPage: React.FunctionComponent = () => {
                             onChange={(value: DropdownItem) => setDropdownList3Selected(value)}
                             more={true}
                             disabled={disabled}
+                            error={error}
                         />
                     </div>
 
@@ -74,6 +82,7 @@ const DropdownPage: React.FunctionComponent = () => {
                             }}
                             native={true}
                             disabled={disabled}
+                            error={error}
                         />
                         <Dropdown
                             label="Native dropdown"
@@ -94,6 +103,7 @@ const DropdownPage: React.FunctionComponent = () => {
                             multi={true}
                             native={true}
                             disabled={disabled}
+                            error={error}
                         />
                     </div>
 
@@ -103,6 +113,12 @@ const DropdownPage: React.FunctionComponent = () => {
                             label="Disabled all"
                             value={disabled}
                             onChange={(e) => setDisabled(e.target.checked)}
+                        />
+                        <Toggle
+                            name="show-error-toggle"
+                            label="Show error messages"
+                            value={!!error}
+                            onChange={handleToggleError}
                         />
                     </div>
                 </div>

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -322,11 +322,11 @@ const Dropdown: React.FunctionComponent<DropdownProps> = (props: DropdownProps):
     // Display the custom dropdown with native elements if prop is set to native
     if (props.native) {
         return (
-            <>
+            <div className="custom-native-dropdown">
                 {props.label && <label className={`dropdown-label ${shouldDisable ? " disabled" : ""}`}>{props.label}</label>}
                 <select
                     disabled={shouldDisable}
-                    className={`form-control${shouldDisable ? " disabled" : ""}${props.className ? ` ${props.className}` : ""}`}
+                    className={`form-control custom-native-dropdown${shouldDisable ? " disabled" : ""}${props.className ? ` ${props.className}` : ""}`}
                     name={props.name}
                     value={props.selectedValue ? (props.selectedValue as DropdownItem).value : ""}
                     onChange={props.onChange}
@@ -340,8 +340,8 @@ const Dropdown: React.FunctionComponent<DropdownProps> = (props: DropdownProps):
                         </option>
                     )}
                 </select>
-                {props.error && <div className="alert alert-danger">{props.error}</div>}
-            </>
+                {props.error && <div className="alert alert-danger custom-alert">{props.error}</div>}
+            </div>
         );
     }
 
@@ -456,7 +456,7 @@ const Dropdown: React.FunctionComponent<DropdownProps> = (props: DropdownProps):
                     }
                 </div>
             </div>
-            {props.error && <div className="alert alert-danger">{props.error}</div>}
+            {props.error && <div className="alert alert-danger custom-alert">{props.error}</div>}
         </>
     );
 };

--- a/src/Dropdown/dropdown-style.scss
+++ b/src/Dropdown/dropdown-style.scss
@@ -268,22 +268,7 @@ $white: #fff;
 }
 
 
-// Native version
-.form-control {
-    &.disabled {
-        border-color: $grey-500;
-        color: $grey-500;
-        background-color: $white;
-    }
-}
-
-.dropdown-label {
-    &.disabled {
-        color: $grey-500;
-    }
-}
-
-.alert {
+.alert.custom-alert {
     padding: 0px 2px;
     margin: 0;
     &.alert-danger {
@@ -292,6 +277,24 @@ $white: #fff;
         border: none;
         border-radius: 0px;
         width: 100%;
+    }
+}
+
+// Native version
+.custom-native-dropdown {
+    margin-bottom: 8px;
+    >.form-control {
+        &.disabled {
+            border-color: $grey-500;
+            color: $grey-500;
+            background-color: $white;
+        }
+    }
+    
+    >.dropdown-label {
+        &.disabled {
+            color: $grey-500;
+        }
     }
 }
 


### PR DESCRIPTION
- [x] Added a toggle which shows and hides example error messages under each dropdown example
![image](https://user-images.githubusercontent.com/49055952/73416561-26770380-4350-11ea-9a2f-123e7d488c42.png)

Oh and also fixes #106 👍 

