### PR TITLE
refactor(button): updates button theme names

### DIFF
--- a/develop/components/pages/ButtonPage.tsx
+++ b/develop/components/pages/ButtonPage.tsx
@@ -11,12 +11,12 @@ const mysvg: JSX.Element = <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 
 const ButtonPage: React.FunctionComponent = () => {
     const themeList: Array<RadioListModel<ButtonTheme>> = [
         { label: "Primary", value: "primary" },
+        { label: "Primary (outlined)", value: "outline-primary" },
         { label: "Secondary", value: "secondary" },
-        { label: "Alternative", value: "alternative" },
         { label: "Danger", value: "danger" },
         { label: "Ghost-dark", value: "ghost-dark" },
         { label: "Ghost-light", value: "ghost-light" },
-        { label: "Anchor", value: "anchor" },
+        { label: "Link", value: "link" },
     ];
     const iconPositionList: Array<RadioListModel<ButtonIconPosition>> = [
         { label: "Right", value: "right" },

--- a/src/Button/Button.test.tsx
+++ b/src/Button/Button.test.tsx
@@ -44,11 +44,12 @@ describe("Component: Button", () => {
     describe("Should render supported themes", () => {
         const list: Array<ButtonTestItem<ButtonTheme, string>> = [
             { value: "primary", expected: "btn-primary" },
-            { value: "secondary", expected: "btn-outline-primary" },
-            { value: "alternative", expected: "btn-secondary" },
+            { value: "outline-primary", expected: "btn-outline-primary" },
+            { value: "secondary", expected: "btn-secondary" },
             { value: "ghost-dark", expected: "btn-ghost-dark" },
             { value: "ghost-light", expected: "btn-ghost-light" },
-            { value: "anchor", expected: "btn-anchor" },
+            { value: "anchor", expected: "btn-link" },
+            { value: "link", expected: "btn-link" },
             { value: "danger", expected: "btn-danger" },
             { value: "unsupported-theme" as any, expected: "btn-primary" },
         ];

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -27,7 +27,7 @@ export const Button: React.NamedExoticComponent<ButtonProps> = React.memo((props
 
     function getButtonTheme(): string {
         switch (props.theme) {
-            case "anchor": return "link";
+            case "anchor": return "link"; @deprecated
             case "outline-primary": case "secondary": case "ghost-dark": case "ghost-light": case "danger": case "link": return props.theme;
             default: return "primary";
         }

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -27,7 +27,10 @@ export const Button: React.NamedExoticComponent<ButtonProps> = React.memo((props
 
     function getButtonTheme(): string {
         switch (props.theme) {
-            case "anchor": return "link"; @deprecated
+            case "anchor": {
+                console.warn("WARNING: 'anchor' is deprecated and will be removed in future versions. Use 'link' instead.");
+                return "link";
+            }
             case "outline-primary": case "secondary": case "ghost-dark": case "ghost-light": case "danger": case "link": return props.theme;
             default: return "primary";
         }

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import "./button-style.scss";
 
-export type ButtonTheme = "primary" | "secondary" | "danger" | "alternative" | "ghost-dark" | "ghost-light" | "anchor";
+export type ButtonTheme = "primary" | "secondary" | "danger" | "outline-primary" | "ghost-dark" | "ghost-light" | "anchor" | "link";
 export type ButtonSizes = "lg" | "md" | "sm";
 export type ButtonIconPosition = "right" | "left";
 export type ButtonType = "button" | "reset" | "submit";
@@ -27,9 +27,8 @@ export const Button: React.NamedExoticComponent<ButtonProps> = React.memo((props
 
     function getButtonTheme(): string {
         switch (props.theme) {
-            case "secondary": return "outline-primary";
-            case "alternative": return "secondary";
-            case "primary": case "ghost-dark": case "ghost-light": case "anchor": case "danger": return props.theme;
+            case "anchor": return "link";
+            case "outline-primary": case "secondary": case "ghost-dark": case "ghost-light": case "danger": case "link": return props.theme;
             default: return "primary";
         }
     }

--- a/src/Button/button-style.scss
+++ b/src/Button/button-style.scss
@@ -76,44 +76,6 @@ button.btn {
         }
     }
 
-    &.btn-anchor {
-        &:not(:disabled) {
-            background: $transparent;
-            border: 0;
-            color: $blue-darker;
-
-            >.button-content>.svg-holder svg {
-                fill: $blue-darker;
-            }
-
-            &:hover {
-                background: $transparent;
-                color: $blue-dark;
-                text-decoration: underline;
-
-                >.button-content>.svg-holder svg {
-                    fill: $blue-dark;
-                }
-            }
-
-            &:active {
-                color: $blue-darker;
-            }
-
-            &:active,
-            &:focus {
-                background: $transparent;
-                text-decoration: underline;
-            }
-        }
-
-        &:disabled {
-            >.button-content>.svg-holder svg {
-                fill: $gray-500;
-            }
-        }
-    }
-
     &.btn-primary {
         >.button-content>.svg-holder svg {
             fill: $white;

--- a/src/Button/readme.md
+++ b/src/Button/readme.md
@@ -34,19 +34,19 @@ These are the current available properties:
 | className?    | `string`                                           | Element class                                        |
 | disabled?     | `boolean`                                          | Disabled status                                      |
 | icon?         | `ReactNode`                                        | Icon to be rendered inside the button                |
-| iconPosition? | `string`<sup>3</sup>                               | Icon position. (default is `left`)                   |
+| iconPosition? | `string`<sup>1</sup>                               | Icon position. (default is `left`)                   |
 | id?           | `string`                                           | Id property                                          |
 | label         | `string`                                           | Button label                                         |
 | name?         | `string`                                           | Name property                                        |
 | onClick       | `(e: React.MouseEvent<HTMLButtonElement>) => void` | Click action                                         |
 | size?         | `string`<sup>2</sup>                               | Based on Bootstrap predefined sizes. (default: `md`) |
-| theme?        | `string`<sup>1</sup>                               | Based on SEB predefined colors. (default: `primary`) |
+| theme?        | `string`<sup>3</sup>                               | Based on SEB predefined colors. (default: `primary`) |
 | title?        | `string`                                           | Element title                                        |
-| type?         | `string`                                           | Button type<sup>4</sup>. (default: `button`)         |
+| type?         | `string`<sup>4</sup>                               | Button type. (default: `button`)                     |
 
 ## Footnote
 
-1. Supported themes: `primary` | `secondary` | `danger` | `alternative` | `ghost-dark` | `ghost-light` | `anchor`
+1. Supported icon positions: `left` | `right`
 2. Supported size: `sm` | `md` | `lg`
-3. Supported icon positions: `left` | `right`
+3. Supported themes: `primary` | `outline-primary` | `secondary` | `danger` | `alternative` | `ghost-dark` | `ghost-light` | `link` /n(We only support these. Any other theme will default back to primary)
 4. Supported button types: `button` | `submit` | `reset`


### PR DESCRIPTION
Updates the theme names: 
- Alternative -> Secondary,
- Secondary -> Primary outlined,
- Anchor -> Link

Since there are some dependencies between design library and Bootstrap, I decided to just follow the naming conventions from [SEB Bootstrap](https://sebgroup.github.io/bootstrap/buttons). 

fix #110

![image](https://user-images.githubusercontent.com/49055952/73624452-ce0b7300-467b-11ea-816b-aec5d06c27e2.png)
