### PR TITLE
feat(table): switching from hardcoded arrow style to css

### DIFF
--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -18,32 +18,6 @@ const ellipsis: JSX.Element = (
         <path d="M192 256c0 17.7-14.3 32-32 32s-32-14.3-32-32 14.3-32 32-32 32 14.3 32 32zm88-32c-17.7 0-32 14.3-32 32s14.3 32 32 32 32-14.3 32-32-14.3-32-32-32zm-240 0c-17.7 0-32 14.3-32 32s14.3 32 32 32 32-14.3 32-32-14.3-32-32-32z" />
     </svg>
 );
-const sortAsc: JSX.Element = (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 644">
-        <path
-            fill="#adadad"
-            transform="translate(0 240)"
-            d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-        />
-        <path
-            transform="translate(0 -100)"
-            d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
-        />
-    </svg>
-);
-const sortDesc: JSX.Element = (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 644">
-        <path
-            transform="translate(0 240)"
-            d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-        />
-        <path
-            fill="#adadad"
-            transform="translate(0 -100)"
-            d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
-        />
-    </svg>
-);
 const defaultSort: JSX.Element = (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 644">
         <path
@@ -500,8 +474,8 @@ const TableUI: React.FunctionComponent<TableUIProps> = React.memo(
                                 >
                                     {header.label}
                                     {props.sortable && header.canSort && (
-                                        <div role="link" className={"icon-holder" + (header.isSorted ? " active" : "")} id={header.accessor}>
-                                            {header.isSorted ? (header.isSortedDesc ? sortDesc : sortAsc) : defaultSort}
+                                        <div role="link" className={"icon-holder" + (header.isSorted ? (header.isSortedDesc ? " desc" : " asc") : "")} id={header.accessor}>
+                                            {defaultSort}
                                         </div>
                                     )}
                                 </th>

--- a/src/Table/table-style.scss
+++ b/src/Table/table-style.scss
@@ -24,10 +24,6 @@ table {
                         cursor: pointer;
                         &:hover {
                             color: $icon-active-color;
-
-                            svg {
-                                fill: $icon-active-color;
-                            }
                         }
                     }
                     &:first-child {
@@ -66,19 +62,26 @@ table {
                         margin-left: 5px;
                         height: $icon-size;
 
-                        svg {
+                        > svg {
                             width: 100%;
                             height: 100%;
                             fill: $icon-color;
                             cursor: pointer;
+                        }
 
-                            &:hover {
-                                fill: $icon-active-color;
+                        &.asc {
+                            > svg {
+                                > path:first-child {
+                                    fill: $icon-active-color;
+                                }
                             }
                         }
-                        &.active {
-                            svg {
-                                fill: $icon-active-color;
+
+                        &.desc {
+                            > svg {
+                                > path:last-child {
+                                    fill: $icon-active-color;
+                                }
                             }
                         }
                     }
@@ -100,7 +103,7 @@ table {
                             flex-wrap: wrap;
                             > .filter-item {
                                 height: $chip-height;
-                                background-color: #e6e6e6;
+                                background-color: $grey-8;
                                 border-radius: 4px;
                                 padding: 4px;
                                 margin: 4px;
@@ -117,9 +120,9 @@ table {
                                     margin-left: 12px;
 
                                     svg {
-                                        fill: black;
+                                        fill: $black;
                                         &:hover {
-                                            fill: red;
+                                            fill: $red;
                                         }
                                     }
                                 }
@@ -193,7 +196,7 @@ table {
                                 &.active {
                                     max-height: 10000px;
                                     width: auto;
-                                    border: 1px solid #007ac7;
+                                    border: 1px solid $blue-darker;
                                     border-radius: 4px;
                                     z-index: 1;
                                     min-width: 160px;


### PR DESCRIPTION
sort arrows colors are currently hardcoded, this fix moves towards colors set from css giving the
ability to override them by the user