### PR TITLE
Create gh-pages.yml

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,4 +25,4 @@ jobs:
       with:
         build_dir: docs
       env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,3 +24,5 @@ jobs:
       uses: crazy-max/ghaction-github-pages@v1.4.0
       with:
         build_dir: docs
+      env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,26 @@
+name: Deploy to Github Pages
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v1.4.1
+
+    - name: Installing dependencies
+      run: npm install
+
+    - name: Generating docs
+      run: npm run docs
+
+    - name: GitHub Pages
+      uses: crazy-max/ghaction-github-pages@v1.4.0
+      with:
+        build_dir: docs


### PR DESCRIPTION
This PR adds a workflow setup that triggers when code is pushed to **master** branch. The workflow with install dependencies, build the docs and publish them on `gh-pages` branch.

The settings of this repository are still not configured to retrieve docs from `gh-pages` yet, I will wait until the next push to verify it's integrity before changing the settings and adding `docs` folder to `.gitignore`