### PR TITLE
feat(datepicker): new datepicker config

### DIFF
--- a/develop/components/pages/DatepickerPage.tsx
+++ b/develop/components/pages/DatepickerPage.tsx
@@ -17,6 +17,7 @@ const DatepickerPage: React.FunctionComponent = () => {
     const [datepicker, setDatepicker] = React.useState<Date>(new Date());
     const [datepicker2, setDatepicker2] = React.useState<Date>(new Date());
     const [datepicker3, setDatepicker3] = React.useState<Date>(new Date());
+    const [datepicker4, setDatepicker4] = React.useState<Date>(new Date());
 
     return (
         <div className="route-template container">
@@ -51,6 +52,11 @@ const DatepickerPage: React.FunctionComponent = () => {
                             clearable={true}
                             showLeadingZeros={false}
                         />
+                    </div>
+
+                    <p>Month picker</p>
+                    <div className="result">
+                        <Datepicker name="datepicker" maxDetail="year" value={datepicker4} onChange={setDatepicker4} minDate={minDate} maxDate={maxDate} clearable={true} />
                     </div>
 
                     <p>Disabled</p>

--- a/src/Datepicker/Datepicker.tsx
+++ b/src/Datepicker/Datepicker.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import DatePicker from "react-date-picker";
 import "./date-picker-style.scss";
+import { Detail } from "react-calendar";
 
 const calendarAltIcon: JSX.Element = (
     <svg name="calendar-alt" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
@@ -26,6 +27,7 @@ export interface DatepickerProps {
     placeholder?: string;
     showLeadingZeros?: boolean;
     value: Date;
+    maxDetail?: Detail;
 }
 
 export const Datepicker: React.FunctionComponent<DatepickerProps> = (props: DatepickerProps): React.ReactElement<void> => {
@@ -45,6 +47,7 @@ export const Datepicker: React.FunctionComponent<DatepickerProps> = (props: Date
                         maxDate={props.maxDate}
                         locale={props.locale}
                         format={props.format}
+                        maxDetail={props.maxDetail}
                         showLeadingZeros={props.showLeadingZeros === undefined ? true : props.showLeadingZeros}
                     />
                     {!props.value && props.placeholder ? (


### PR DESCRIPTION
allow user to use datepicker as month picker, year picker

by default maxDetail will be set to "month" which will display the default date picker

`maxDetail="year"`
![image](https://user-images.githubusercontent.com/12553063/79288914-941be000-7efa-11ea-93e9-53a729037788.png)

`maxDetail="decade"`
![image](https://user-images.githubusercontent.com/12553063/79288979-be6d9d80-7efa-11ea-910f-32aa8a15b57f.png)

`maxDetail="century"`
![image](https://user-images.githubusercontent.com/12553063/79289041-de04c600-7efa-11ea-8a92-26fa11f51da0.png)
