### PR TITLE
feat(dropdown): add placeholdersConfig attribute to dropdown

### DIFF
--- a/src/Dropdown/Dropdown.test.tsx
+++ b/src/Dropdown/Dropdown.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dropdown, DropdownProps } from "./Dropdown";
+import { Dropdown, DropdownProps, DropdownItem } from "./Dropdown";
 import { unmountComponentAtNode, render } from "react-dom";
 import { act } from "react-dom/test-utils";
 
@@ -15,6 +15,7 @@ describe("Component: Dropdown", () => {
                 { label: "A", value: "a" },
                 { label: "B", value: "b" },
                 { label: "C", value: "c" },
+                { label: "D", value: "d" },
             ],
             onChange: jest.fn(),
             selectedValue: null,
@@ -213,7 +214,7 @@ describe("Component: Dropdown", () => {
         const title: Element = container.querySelector(".title");
         expect(title.innerHTML).toBe("Select ...");
         const options: NodeListOf<Element> = container.querySelectorAll(".custom-dropdown-item:not(.select-all)");
-        expect(options.length).toBe(3);
+        expect(options.length).toBe(props.list.length);
 
         act(() => {
             options.item(options.length - 1).dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -231,7 +232,23 @@ describe("Component: Dropdown", () => {
             render(<Dropdown {...props} selectedValue={[{ ...DEFAULT_PROPS.list[0] }, { ...DEFAULT_PROPS.list[1] }]} />, container);
         });
 
-        expect(title.innerHTML).toBe("2 Selected");
+        expect(title.innerHTML).toBe(
+            DEFAULT_PROPS.list
+                .slice(0, 2)
+                .map(({ label }: DropdownItem) => label)
+                .join(", ")
+        );
+
+        act(() => {
+            render(<Dropdown {...props} selectedValue={DEFAULT_PROPS.list.slice(0, 3)} />, container);
+        });
+
+        expect(title.innerHTML).toBe(
+            `${DEFAULT_PROPS.list
+                .slice(0, 2)
+                .map(({ label }: DropdownItem) => label)
+                .join(", ")}... (+1)`
+        );
 
         act(() => {
             render(<Dropdown {...props} selectedValue={[...DEFAULT_PROPS.list]} />, container);
@@ -252,7 +269,7 @@ describe("Component: Dropdown", () => {
         });
 
         const options: NodeListOf<Element> = container.querySelectorAll(".custom-dropdown-item:not(.select-all)");
-        expect(options.length).toBe(3);
+        expect(options.length).toBe(props.list.length);
 
         expect(options.item(0).classList.contains("selected")).toBeTruthy();
         expect(options.item(1).classList.contains("selected")).toBeFalsy();
@@ -468,7 +485,7 @@ describe("Component: Dropdown", () => {
             render(<Dropdown {...props} selectedValue={props.list} />, container);
         });
 
-        expect(container.querySelectorAll(".custom-dropdown-item.selected").length).toBe(4);
+        expect(container.querySelectorAll(".custom-dropdown-item.selected").length).toBe(props.list.length + 1);
     });
 
     it("Should allow user to set custom label for select all item", () => {
@@ -477,7 +494,7 @@ describe("Component: Dropdown", () => {
             ...DEFAULT_PROPS,
             selectedValue: [{ ...DEFAULT_PROPS.list[0] }],
             multi: true,
-            selectAllText: customText,
+            selectAllOptionText: customText,
         };
 
         act(() => {
@@ -504,7 +521,7 @@ describe("Component: Dropdown", () => {
         expect(target).toBeTruthy();
 
         const selectedOptions: NodeListOf<Element> = container.querySelectorAll(".custom-dropdown-item.selected");
-        expect(selectedOptions.length).toBe(4);
+        expect(selectedOptions.length).toBe(props.list.length + 1);
 
         act(() => {
             target.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -532,7 +549,7 @@ describe("Component: Dropdown", () => {
         });
 
         const options: NodeListOf<Element> = container.querySelectorAll(".custom-dropdown-item");
-        expect(options.length).toBe(3);
+        expect(options.length).toBe(props.list.length);
 
         const searchInput: HTMLInputElement = container.querySelector(".search-input");
         expect(searchInput.getAttribute("value")).toBe("");
@@ -557,7 +574,7 @@ describe("Component: Dropdown", () => {
         });
 
         const options: NodeListOf<Element> = container.querySelectorAll(".custom-dropdown-item");
-        expect(options.length).toBe(3);
+        expect(options.length).toBe(props.list.length);
 
         options.forEach((option: Element) => {
             expect(option.classList.contains("highlighted")).toBeFalsy();
@@ -596,7 +613,7 @@ describe("Component: Dropdown", () => {
         const toggle: Element = container.querySelector(".custom-dropdown-toggle");
         expect(toggle).toBeTruthy();
         const options = container.querySelectorAll(".custom-dropdown-item");
-        expect(options.length).toBe(3);
+        expect(options.length).toBe(DEFAULT_PROPS.list.length);
 
         act(() => {
             toggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -613,6 +630,7 @@ describe("Component: Dropdown", () => {
         expect(options.item(0).classList.contains("highlighted")).toBeTruthy();
         expect(options.item(1).classList.contains("highlighted")).toBeFalsy();
         expect(options.item(2).classList.contains("highlighted")).toBeFalsy();
+        expect(options.item(3).classList.contains("highlighted")).toBeFalsy();
 
         act(() => {
             menu.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "arrowdown" }));
@@ -621,6 +639,7 @@ describe("Component: Dropdown", () => {
         expect(options.item(0).classList.contains("highlighted")).toBeFalsy();
         expect(options.item(1).classList.contains("highlighted")).toBeTruthy();
         expect(options.item(2).classList.contains("highlighted")).toBeFalsy();
+        expect(options.item(3).classList.contains("highlighted")).toBeFalsy();
 
         act(() => {
             menu.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "arrowup" }));
@@ -629,6 +648,7 @@ describe("Component: Dropdown", () => {
         expect(options.item(0).classList.contains("highlighted")).toBeTruthy();
         expect(options.item(1).classList.contains("highlighted")).toBeFalsy();
         expect(options.item(2).classList.contains("highlighted")).toBeFalsy();
+        expect(options.item(3).classList.contains("highlighted")).toBeFalsy();
 
         act(() => {
             menu.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "arrowup" }));
@@ -637,6 +657,7 @@ describe("Component: Dropdown", () => {
         expect(options.item(0).classList.contains("highlighted")).toBeFalsy();
         expect(options.item(1).classList.contains("highlighted")).toBeFalsy();
         expect(options.item(2).classList.contains("highlighted")).toBeFalsy();
+        expect(options.item(3).classList.contains("highlighted")).toBeFalsy();
 
         act(() => {
             menu.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "arrowup" }));
@@ -644,7 +665,8 @@ describe("Component: Dropdown", () => {
 
         expect(options.item(0).classList.contains("highlighted")).toBeFalsy();
         expect(options.item(1).classList.contains("highlighted")).toBeFalsy();
-        expect(options.item(2).classList.contains("highlighted")).toBeTruthy();
+        expect(options.item(2).classList.contains("highlighted")).toBeFalsy();
+        expect(options.item(3).classList.contains("highlighted")).toBeTruthy();
 
         act(() => {
             menu.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "arrowdown" }));
@@ -653,6 +675,7 @@ describe("Component: Dropdown", () => {
         expect(options.item(0).classList.contains("highlighted")).toBeFalsy();
         expect(options.item(1).classList.contains("highlighted")).toBeFalsy();
         expect(options.item(2).classList.contains("highlighted")).toBeFalsy();
+        expect(options.item(3).classList.contains("highlighted")).toBeFalsy();
 
         act(() => {
             menu.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "arrowdown" }));
@@ -661,6 +684,7 @@ describe("Component: Dropdown", () => {
         expect(options.item(0).classList.contains("highlighted")).toBeTruthy();
         expect(options.item(1).classList.contains("highlighted")).toBeFalsy();
         expect(options.item(2).classList.contains("highlighted")).toBeFalsy();
+        expect(options.item(3).classList.contains("highlighted")).toBeFalsy();
 
         act(() => {
             menu.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "enter" }));
@@ -696,7 +720,7 @@ describe("Component: Dropdown", () => {
         const toggle: Element = container.querySelector(".custom-dropdown-toggle");
         expect(toggle).toBeTruthy();
         const options: NodeListOf<Element> = container.querySelectorAll(".custom-dropdown-item");
-        expect(options.length).toBe(4);
+        expect(options.length).toBe(props.list.length + 1);
 
         act(() => {
             toggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -804,7 +828,7 @@ describe("Component: Dropdown", () => {
         });
 
         const options: NodeListOf<Element> = container.querySelectorAll(".custom-dropdown-item:not(.search-input)");
-        expect(options.length).toBe(3);
+        expect(options.length).toBe(DEFAULT_PROPS.list.length);
         expect(options.item(0).classList.contains("highlighted")).toBeTruthy();
         expect(document.activeElement).toBe(options.item(0));
 

--- a/src/Dropdown/Dropdown.test.tsx
+++ b/src/Dropdown/Dropdown.test.tsx
@@ -471,6 +471,24 @@ describe("Component: Dropdown", () => {
         expect(container.querySelectorAll(".custom-dropdown-item.selected").length).toBe(4);
     });
 
+    it("Should allow user to set custom label for select all item", () => {
+        const customLabel: string = "customLabel";
+        const props: DropdownProps = {
+            ...DEFAULT_PROPS,
+            selectedValue: [{ ...DEFAULT_PROPS.list[0] }],
+            multi: true,
+            selectAllLabel: customLabel,
+        };
+
+        act(() => {
+            render(<Dropdown {...props} />, container);
+        });
+
+        const target: Element = container.querySelector("#select-all");
+        expect(target).toBeTruthy();
+        expect(target.nextSibling.textContent).toBe(customLabel);
+    });
+
     it("Should toggle deselect all items when select all button is pressed and all items are already selected", () => {
         const props: DropdownProps = {
             ...DEFAULT_PROPS,

--- a/src/Dropdown/Dropdown.test.tsx
+++ b/src/Dropdown/Dropdown.test.tsx
@@ -472,12 +472,12 @@ describe("Component: Dropdown", () => {
     });
 
     it("Should allow user to set custom label for select all item", () => {
-        const customLabel: string = "customLabel";
+        const customText: string = "customText";
         const props: DropdownProps = {
             ...DEFAULT_PROPS,
             selectedValue: [{ ...DEFAULT_PROPS.list[0] }],
             multi: true,
-            selectAllLabel: customLabel,
+            selectAllText: customText,
         };
 
         act(() => {
@@ -486,7 +486,7 @@ describe("Component: Dropdown", () => {
 
         const target: Element = container.querySelector("#select-all");
         expect(target).toBeTruthy();
-        expect(target.nextSibling.textContent).toBe(customLabel);
+        expect(target.nextSibling.textContent).toBe(customText);
     });
 
     it("Should toggle deselect all items when select all button is pressed and all items are already selected", () => {

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -22,6 +22,7 @@ export type DropdownChangeEvent = DropdownItem | Array<DropdownItem> | React.Cha
 export interface DropdownProps {
     className?: string;
     clearable?: boolean;
+    selectAllLabel?: string;
     disabled?: boolean;
     error?: string;
     id?: string;
@@ -174,7 +175,7 @@ const Dropdown: React.FunctionComponent<DropdownProps> = (props: DropdownProps):
             id: "select-all",
             dropdownItem: {
                 value: "select-all",
-                label: "Select All",
+                label: props.selectAllLabel || "Select All",
             },
             selected: allSelected,
             className: `dropdown-item select-all custom-dropdown-item multi${allSelected ? " selected" : ""}`,

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -34,6 +34,7 @@ export interface DropdownProps {
     onChange: (event: DropdownChangeEvent) => void;
     placeholder?: string;
     searchable?: boolean;
+    selectAllOptionText?: string;
     selectAllText?: string;
     searchPlaceholder?: string;
     selectedValue: DropdownItem | Array<DropdownItem>;
@@ -56,6 +57,7 @@ const moreIcon: JSX.Element = (
 );
 
 const Dropdown: React.FunctionComponent<DropdownProps> = (props: DropdownProps): React.ReactElement<void> => {
+    const selectedDisplayLength: number = 2;
     // COMPONENT INTERNAL STATE INIT ================================
     const [open, setOpen] = React.useState<boolean>(false);
     const [shouldFocus, setShouldFocus] = React.useState<boolean>(false);
@@ -175,7 +177,7 @@ const Dropdown: React.FunctionComponent<DropdownProps> = (props: DropdownProps):
             id: "select-all",
             dropdownItem: {
                 value: "select-all",
-                label: props.selectAllText || "Select All",
+                label: props.selectAllOptionText || "Select All",
             },
             selected: allSelected,
             className: `dropdown-item select-all custom-dropdown-item multi${allSelected ? " selected" : ""}`,
@@ -321,13 +323,17 @@ const Dropdown: React.FunctionComponent<DropdownProps> = (props: DropdownProps):
         }
         if (selectedList && selectedList.length > 0) {
             if (allSelected) {
-                return `All selected (${selectedList.length})`;
+                return props.selectAllText || `All selected (${selectedList.length})`;
             }
             if (props.multi) {
                 if (selectedList.length === 1) {
                     return selectedList[0].label;
                 }
-                return selectedList.length + " Selected"; // TODO should be like this example: 1st Item, 2nd Item... (+2)
+                const displayText: string = selectedList
+                    .slice(0, selectedDisplayLength)
+                    .map(({ label }: DropdownItem) => label)
+                    .join(", ");
+                return `${displayText}${selectedList.length > selectedDisplayLength ? `... (+${selectedList.slice(selectedDisplayLength).length})` : ""}`;
             }
             return (props.selectedValue as DropdownItem).label;
         }

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -22,7 +22,6 @@ export type DropdownChangeEvent = DropdownItem | Array<DropdownItem> | React.Cha
 export interface DropdownProps {
     className?: string;
     clearable?: boolean;
-    selectAllLabel?: string;
     disabled?: boolean;
     error?: string;
     id?: string;
@@ -35,6 +34,7 @@ export interface DropdownProps {
     onChange: (event: DropdownChangeEvent) => void;
     placeholder?: string;
     searchable?: boolean;
+    selectAllText?: string;
     searchPlaceholder?: string;
     selectedValue: DropdownItem | Array<DropdownItem>;
 }
@@ -175,7 +175,7 @@ const Dropdown: React.FunctionComponent<DropdownProps> = (props: DropdownProps):
             id: "select-all",
             dropdownItem: {
                 value: "select-all",
-                label: props.selectAllLabel || "Select All",
+                label: props.selectAllText || "Select All",
             },
             selected: allSelected,
             className: `dropdown-item select-all custom-dropdown-item multi${allSelected ? " selected" : ""}`,

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -19,6 +19,14 @@ interface DisplayDropdownItem extends UniqueDropdownItem {
 
 export type DropdownChangeEvent = DropdownItem | Array<DropdownItem> | React.ChangeEvent<HTMLSelectElement>;
 
+export interface DropdownPlaceholder {
+    searchText?: string;
+    selectAllOptionText?: string;
+    selectAllText?: string;
+    emptyText?: string;
+    noResultText?: string;
+}
+
 export interface DropdownProps {
     className?: string;
     clearable?: boolean;
@@ -34,8 +42,8 @@ export interface DropdownProps {
     onChange: (event: DropdownChangeEvent) => void;
     placeholder?: string;
     searchable?: boolean;
-    selectAllOptionText?: string;
-    selectAllText?: string;
+    placeholdersConfig?: DropdownPlaceholder;
+    /** @deprecated use placedholdersConfig.searchText instead */
     searchPlaceholder?: string;
     selectedValue: DropdownItem | Array<DropdownItem>;
 }
@@ -177,7 +185,7 @@ const Dropdown: React.FunctionComponent<DropdownProps> = (props: DropdownProps):
             id: "select-all",
             dropdownItem: {
                 value: "select-all",
-                label: props.selectAllOptionText || "Select All",
+                label: props.placeholdersConfig?.selectAllOptionText || "Select All",
             },
             selected: allSelected,
             className: `dropdown-item select-all custom-dropdown-item multi${allSelected ? " selected" : ""}`,
@@ -319,11 +327,11 @@ const Dropdown: React.FunctionComponent<DropdownProps> = (props: DropdownProps):
     /** Returns the appropriate title for different situations and component types */
     const getTitleLabel = () => {
         if (uniqueList && uniqueList.length === 0) {
-            return "Empty";
+            return props.placeholdersConfig?.emptyText || "Empty";
         }
         if (selectedList && selectedList.length > 0) {
             if (allSelected) {
-                return props.selectAllText || `All selected (${selectedList.length})`;
+                return props.placeholdersConfig?.selectAllText || `All selected (${selectedList.length})`;
             }
             if (props.multi) {
                 if (selectedList.length === 1) {
@@ -416,7 +424,7 @@ const Dropdown: React.FunctionComponent<DropdownProps> = (props: DropdownProps):
                             type="search"
                             className="search-input"
                             name="search-input"
-                            placeholder={props.searchPlaceholder || "Search ..."}
+                            placeholder={props.placeholdersConfig?.searchText || props.searchPlaceholder || "Search ..."}
                             value={searchText}
                             onChange={handleOnChangeSearch}
                         />
@@ -475,7 +483,7 @@ const Dropdown: React.FunctionComponent<DropdownProps> = (props: DropdownProps):
 
                 {displayList.length === 0 && (
                     <a className={`dropdown-item custom-dropdown-item disabled`}>
-                        <div className="label">No results</div>
+                        <div className="label">{props.placeholdersConfig?.noResultText || "No results"}</div>
                     </a>
                 )}
             </div>

--- a/src/Dropdown/readme.md
+++ b/src/Dropdown/readme.md
@@ -52,6 +52,7 @@ These are the current available properties:
 | placeholder?       | `string`                                           | Optional text to display inside the toggle button when no item selected |
 | searchable?        | `boolean`                                          | Enables searching                                                       |
 | searchPlaceholder? | `string`                                           | Optional text to display inside the empty search bar                    |
+| selectAllLabel?    | `string`                                           | Optional text to display as select all label if `multi` is enabled      |
 | selectedValue      | `Array<DropdownItem> \| DropdownItem`              | An array of the currently selected dropdown item(s)                     |
 
 ## Important

--- a/src/Dropdown/readme.md
+++ b/src/Dropdown/readme.md
@@ -52,7 +52,7 @@ These are the current available properties:
 | placeholder?       | `string`                                           | Optional text to display inside the toggle button when no item selected |
 | searchable?        | `boolean`                                          | Enables searching                                                       |
 | searchPlaceholder? | `string`                                           | Optional text to display inside the empty search bar                    |
-| selectAllLabel?    | `string`                                           | Optional text to display as select all label if `multi` is enabled      |
+| selectAllText?    | `string`                                           | Optional text to display as select all label if `multi` is enabled      |
 | selectedValue      | `Array<DropdownItem> \| DropdownItem`              | An array of the currently selected dropdown item(s)                     |
 
 ## Important

--- a/src/Dropdown/readme.md
+++ b/src/Dropdown/readme.md
@@ -35,25 +35,26 @@ This React component supports customization and configurations. The component na
 
 These are the current available properties:
 
-| Property           | Type                                               | Description                                                             |
-| ------------------ | -------------------------------------------------- | ----------------------------------------------------------------------- |
-| className?         | `string`                                           | Custom class                                                            |
-| clearable?         | `boolean`                                          | Enables clearning the value, ignored if `multi` is enabled              |
-| disabled?          | `boolean`                                          | Disabled status                                                         |
-| error?             | `string`                                           | Optional error string to be displayed under the dropdown                |
-| id?                | `string`                                           | Element id                                                              |
-| label?             | `string`                                           | Optional label to display above the dropdown                            |
-| list               | `Array<DropdownItem>` <sup>1</sup>                 | An array of all the dropdown items to display                           |
-| more?              | `boolean`                                          | Version of the component with a more menu button alligned to the right  |
-| multi?             | `boolean`                                          | Enables selecting multiple choices                                      |
-| name?              | `string`                                           | Element name                                                            |
-| native?            | `boolean`                                          | A mobile friendly version using native `<select>` html element          |
-| onChange           | `(value: DropdownChangeEvent) => void`<sup>2</sup> | On change event callback                                                |
-| placeholder?       | `string`                                           | Optional text to display inside the toggle button when no item selected |
-| searchable?        | `boolean`                                          | Enables searching                                                       |
-| searchPlaceholder? | `string`                                           | Optional text to display inside the empty search bar                    |
-| selectAllText?    | `string`                                           | Optional text to display as select all label if `multi` is enabled      |
-| selectedValue      | `Array<DropdownItem> \| DropdownItem`              | An array of the currently selected dropdown item(s)                     |
+| Property                | Type                                               | Description                                                                  |
+| ----------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------- |
+| className?              | `string`                                           | Custom class                                                                 |
+| clearable?              | `boolean`                                          | Enables clearning the value, ignored if `multi` is enabled                   |
+| disabled?               | `boolean`                                          | Disabled status                                                              |
+| error?                  | `string`                                           | Optional error string to be displayed under the dropdown                     |
+| id?                     | `string`                                           | Element id                                                                   |
+| label?                  | `string`                                           | Optional label to display above the dropdown                                 |
+| list                    | `Array<DropdownItem>` <sup>1</sup>                 | An array of all the dropdown items to display                                |
+| more?                   | `boolean`                                          | Version of the component with a more menu button alligned to the right       |
+| multi?                  | `boolean`                                          | Enables selecting multiple choices                                           |
+| name?                   | `string`                                           | Element name                                                                 |
+| native?                 | `boolean`                                          | A mobile friendly version using native `<select>` html element               |
+| onChange                | `(value: DropdownChangeEvent) => void`<sup>2</sup> | On change event callback                                                     |
+| placeholder?            | `string`                                           | Optional text to display inside the toggle button when no item selected      |
+| searchable?             | `boolean`                                          | Enables searching                                                            |
+| searchPlaceholder?      | `string`                                           | Optional text to display inside the empty search bar                         |
+| selectAllText?          | `string`                                           | Optional text to display when all options are selected if `multi` is enabled |
+| selectAllOptionText?    | `string`                                           | Optional text to display as select all label if `multi` is enabled           |
+| selectedValue           | `Array<DropdownItem> \| DropdownItem`              | An array of the currently selected dropdown item(s)                          |
 
 ## Important
 When `multi` and `native` props are used together the change event will return a change event as normal, however, setting the value will required processing of the change event. This is a sample implementation of it:

--- a/src/Dropdown/readme.md
+++ b/src/Dropdown/readme.md
@@ -51,9 +51,8 @@ These are the current available properties:
 | onChange                | `(value: DropdownChangeEvent) => void`<sup>2</sup> | On change event callback                                                     |
 | placeholder?            | `string`                                           | Optional text to display inside the toggle button when no item selected      |
 | searchable?             | `boolean`                                          | Enables searching                                                            |
-| searchPlaceholder?      | `string`                                           | Optional text to display inside the empty search bar                         |
-| selectAllText?          | `string`                                           | Optional text to display when all options are selected if `multi` is enabled |
-| selectAllOptionText?    | `string`                                           | Optional text to display as select all label if `multi` is enabled           |
+| searchPlaceholder?      | `string`                                           | **```[Deprecated]```** Optional text to display inside the empty search bar  |        
+| placeholdersConfig?     | `DropdownPlaceholder`<sup>3</sup>                  | Optional text to display placeholder                                         |
 | selectedValue           | `Array<DropdownItem> \| DropdownItem`              | An array of the currently selected dropdown item(s)                          |
 
 ## Important
@@ -92,4 +91,15 @@ interface DropdownItem<T = any> {
     - Multi: `Array<DropdownItem>`
     - Native: `React.ChangeEvent<HTMLSelectElement>`
 
+3. `placedholdersConfig` items has an exported interface named `DropdownPlaceholder`
+
+```typescript
+interface DropdownPlaceholder {
+    searchText?: string;
+    selectAllOptionText?: string;
+    selectAllText?: string;
+    emptyText?: string;
+    noResultText?: string;
+}
+```
 


### PR DESCRIPTION
- allow user to pass in custom label for select all item in dropdown.
- deprecate searchPlaceholder
```
interface DropdownPlaceholder {
    searchText?: string;
    selectAllOptionText?: string;
    selectAllText?: string;
    emptyText?: string;
    noResultText?: string;
}