### PR TITLE
fix(modal): fix modal initial state that causes it to glitch

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -21,36 +21,41 @@ export interface ModalProps {
     toggle: boolean;
 }
 
-export const Modal: React.FC<ModalProps> = (props: ModalProps) => {
-    const mounted: React.MutableRefObject<boolean> = React.useRef<boolean>(false);
+export const Modal: React.FC<ModalProps> = React.memo((props: ModalProps) => {
+    const prestine: React.MutableRefObject<boolean> = React.useRef<boolean>(true);
+    const [className, setClassName] = React.useState<string>("seb modal");
+
+    React.useEffect(() => {
+        let classNames: string = "seb modal";
+        classNames += props.toggle ? " show" : prestine.current ? "" : " hide";
+        classNames += props.centered ? " modal-centered" : "";
+        classNames += !!props.position ? " modal-aside modal-aside-" + (props.position === "left" ? "left" : "right") : "";
+        classNames += props.fullscreen ? " modal-fullscreen" : "";
+        classNames += props.className ? ` ${props.className}` : "";
+        setClassName(classNames);
+    }, [props.toggle, props.centered, props.position, props.fullscreen, props.className]);
+
+    React.useEffect(() => {
+        prestine.current = false;
+    }, [props.toggle]);
+
     /**
      * Dismisses the modal
      * @param {React.MouseEvent} event clicked element
      */
-    function onDismiss(event: React.MouseEvent<HTMLDivElement>): void {
-        event && event.stopPropagation();
-        if (!props.disableBackdropDismiss) {
-            props.onDismiss ? props.onDismiss() : console.warn("onDismiss is compulsory in Modal!");
-        }
-    }
-
-    let classNames: string = "seb modal";
-    classNames += props.toggle ? " show" : !mounted.current ? "" : " hide";
-    classNames += props.centered ? " modal-centered" : "";
-    classNames += !!props.position ? " modal-aside modal-aside-" + (props.position === "left" ? "left" : "right") : "";
-    classNames += props.fullscreen ? " modal-fullscreen" : "";
-    classNames += props.className ? ` ${props.className}` : "";
-
-    let dialogClassname: string = "modal-dialog";
-    dialogClassname += props.size ? ` ${props.size}` : "";
-
-    React.useEffect(() => {
-        mounted.current = true;
-    }, []);
+    const onDismiss = React.useCallback(
+        (event: React.MouseEvent<HTMLDivElement>): void => {
+            event && event.stopPropagation();
+            if (!props.disableBackdropDismiss) {
+                props.onDismiss ? props.onDismiss() : console.warn("onDismiss is compulsory in Modal!");
+            }
+        },
+        [props.onDismiss, props.disableBackdropDismiss]
+    );
 
     return (
-        <div className={classNames} id={props.id} aria-label={props.ariaLabel} aria-describedby={props.ariaDescribedby} role="dialog" tabIndex={-1} aria-modal="true" onClick={onDismiss}>
-            <div role="document" className={dialogClassname} onClick={(e) => e.stopPropagation()}>
+        <div className={className} id={props.id} aria-label={props.ariaLabel} aria-describedby={props.ariaDescribedby} role="dialog" tabIndex={-1} aria-modal="true" onClick={onDismiss}>
+            <div role="document" className={"modal-dialog" + (props.size ? ` ${props.size}` : "")} onClick={(e) => e.stopPropagation()}>
                 <div className="modal-content">
                     {props.header && <div className="modal-header">{props.header}</div>}
                     {props.body && <div className="modal-body">{props.body}</div>}
@@ -59,4 +64,4 @@ export const Modal: React.FC<ModalProps> = (props: ModalProps) => {
             </div>
         </div>
     );
-};
+});


### PR DESCRIPTION
It fixes the modal's initial state glitch by adding the following:
1. Wrapping the component with `React.memo`
2. Moving class name to a react effect hook
3. Introducing `pristine` check to verify that the toggle has changed