### PR TITLE
fix(dropdown): fix stale search keyword

### DIFF
--- a/lib/src/Dropdown/Dropdown.test.tsx
+++ b/lib/src/Dropdown/Dropdown.test.tsx
@@ -144,6 +144,15 @@ describe("Component: Dropdown", () => {
         act(() => Simulate.change(searchField, { target: { value: "second" } as any }));
 
         expect(document.body.querySelectorAll(".custom-control")).toHaveLength(1);
+
+        // if the searchable prop is changed back to false
+        act(() => {
+            render(<Dropdown>{testOptions}</Dropdown>, container);
+        });
+
+        // The search field should be reset to empty string
+        // so all the elements should be visible again
+        expect(document.body.querySelectorAll(".custom-control")).toHaveLength(4);
     });
 
     it("Should allow the value to be cleared when clearable is enabled", () => {

--- a/lib/src/Dropdown/Dropdown.tsx
+++ b/lib/src/Dropdown/Dropdown.tsx
@@ -203,6 +203,10 @@ export const Dropdown: React.FC<DropdownProps> = React.forwardRef(
         }, [props.value]);
 
         React.useEffect(() => {
+            !searchable && setSearchKeyword("");
+        }, [searchable]);
+
+        React.useEffect(() => {
             if (!isMobile) {
                 const detectBlur = (event: MouseEvent) => {
                     if (!dropdownRef.current.contains(event.target as any) && !menuRef.current.contains(event.target as any)) {


### PR DESCRIPTION
fix the dropdown so when the searchable prop changes dynamically the search keyword is reset

fix #601

https://user-images.githubusercontent.com/49055952/117115660-02f70000-adc0-11eb-91fb-6cee6ea456f0.mov

