### PR TITLE
docs(gh-pages): fix documentation version dropdown

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
         uses: octokit/request-action@v2.x
         id: get_latest_release
         with:
-          route: GET /repos/kherp/react-components/tags
+          route: GET /repos/sebgroup/react-components/tags
           owner: octokit
           repo: request-action
         env:


### PR DESCRIPTION
documentation in github pages is showing wrong version due to wrong repo set in yaml
