### PR TITLE
Refactor/tab

### DIFF
--- a/docs/src/components/DocsAPIs.tsx
+++ b/docs/src/components/DocsAPIs.tsx
@@ -16,7 +16,7 @@ const DocsAPI: React.FC<DocsAPIProps> = (props: DocsAPIProps) => {
 
     return (
         !!props.list?.length && (
-            <div className="apis">
+            <div className="apis" role="tabpanel" tabIndex={0}>
                 <h3>Inputs</h3>
                 <div className="card">
                     <table className="table table-striped">

--- a/docs/src/components/DocsPlaygroud.tsx
+++ b/docs/src/components/DocsPlaygroud.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import classnames from "classnames";
 import { CodeSnippet } from "./CodeSnippet";
+import { TabItem, Tabs } from "@sebgroup/react-components/Tabs";
 
 export type BackgroundTheme = "primary" | "secondary" | "danger" | "warning" | "success" | "dark" | "light";
 
@@ -23,19 +24,19 @@ const DocsPlayground: React.FC<DocsPlaygroundProps> = (props: DocsPlaygroundProp
     }, []);
 
     return (
-        <div className={classnames("playground card", props.className)}>
-            <nav className="nav">
+        <div className={classnames("playground card", props.className)} role="tabpanel" tabIndex={0}>
+            <Tabs className="nav" value={activeTab} onTabChange={switchTab}>
                 {navs.map((item: string, index: number) => (
-                    <a key={index} className={classnames("nav-link", { active: activeTab === index })} onClick={() => switchTab(index)} data-value={index}>
+                    <TabItem key={index} className={classnames("nav-link")}>
                         {item}
-                    </a>
+                    </TabItem>
                 ))}
-            </nav>
+            </Tabs>
 
             {props.controls && <h4 className="apis-title">Try these props</h4>}
             {
                 [
-                    <div className={classnames("example", { [`bg-${props.exampleTheme}`]: props.exampleTheme })}>
+                    <div className={classnames("example", { [`bg-${props.exampleTheme}`]: props.exampleTheme })} role="tabpanel" tabIndex={0}>
                         <div className="content">{props.example}</div>
                         {props.exampleTheme && (
                             <div className={classnames("footnote", { "text-light": props.exampleTheme.includes("dark") })}>
@@ -43,7 +44,7 @@ const DocsPlayground: React.FC<DocsPlaygroundProps> = (props: DocsPlaygroundProp
                             </div>
                         )}
                     </div>,
-                    <CodeSnippet angular language={"jsx"}>
+                    <CodeSnippet angular language={"jsx"} role="tabpanel" tabIndex={0}>
                         {props.code}
                     </CodeSnippet>,
                 ][activeTab]

--- a/docs/src/pages/docs/tabs.tsx
+++ b/docs/src/pages/docs/tabs.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Docs from "@common/Docs";
 import { Tabs, TabItem } from "@sebgroup/react-components/Tabs";
+import { useDynamicForm } from "@sebgroup/react-components/hooks/useDynamicForm";
 
 const importString: string = require("!raw-loader!@sebgroup/react-components/Tabs/Tabs");
 const code: string = `<Tabs value={value} onTabChange={setValue}>
@@ -12,17 +13,25 @@ const code: string = `<Tabs value={value} onTabChange={setValue}>
 const TabsPage: React.FC = React.memo(() => {
     const [value, setValue] = React.useState<number>(0);
 
+    const [renderForm, { controls }] = useDynamicForm([
+        {
+            key: "controls",
+            items: [{ key: "autoSelectOnFocus", label: "Auto select on focus", controlType: "Checkbox" }],
+        },
+    ]);
+
     return (
         <Docs
             mainFile={importString}
             example={
-                <Tabs value={value} onTabChange={setValue}>
+                <Tabs value={value} onTabChange={setValue} autoSelectOnFocus={!!controls.autoSelectOnFocus} onTabDelete={(index: number) => console.log("on delete", index)}>
                     <TabItem>First</TabItem>
                     <TabItem>Second</TabItem>
-                    <TabItem>Third</TabItem>
+                    <TabItem disabled={false}>Third</TabItem>
                     <TabItem disabled>Fourth</TabItem>
                 </Tabs>
             }
+            controls={renderForm()}
             code={code}
         />
     );

--- a/docs/src/pages/docs/tabs.tsx
+++ b/docs/src/pages/docs/tabs.tsx
@@ -27,7 +27,7 @@ const TabsPage: React.FC = React.memo(() => {
                 <Tabs value={value} onTabChange={setValue} autoSelectOnFocus={!!controls.autoSelectOnFocus} onTabDelete={(index: number) => console.log("on delete", index)}>
                     <TabItem>First</TabItem>
                     <TabItem>Second</TabItem>
-                    <TabItem disabled={false}>Third</TabItem>
+                    <TabItem>Third</TabItem>
                     <TabItem disabled>Fourth</TabItem>
                 </Tabs>
             }

--- a/docs/src/styles/playground.scss
+++ b/docs/src/styles/playground.scss
@@ -35,6 +35,8 @@
             font-size: $h4-font-size;
             &.active {
                 border-bottom-color: $green-dark;
+                background-color: transparent;
+                color: $blue-darker;
             }
             &:not(.active) {
                 cursor: pointer;

--- a/lib/src/Tabs/TabItem.tsx
+++ b/lib/src/Tabs/TabItem.tsx
@@ -18,9 +18,10 @@ export const TabItem: React.FC<TabItemProps> = React.forwardRef(({ wrapperProps 
                 href={props.href || "#"}
                 ref={ref}
                 role="tab"
-                tabIndex={0}
+                tabIndex={active ? 0 : -1}
                 aria-selected={active}
                 aria-controls={props["aria-controls"] || `link-${props.id}`}
+                data-disabled={disabled}
                 className={classnames("nav-link", { active, disabled }, props.className)}
             />
         </li>

--- a/lib/src/Tabs/Tabs.test.tsx
+++ b/lib/src/Tabs/Tabs.test.tsx
@@ -1,10 +1,32 @@
 import React from "react";
 import { unmountComponentAtNode, render } from "react-dom";
-import { Tabs, TabItem } from ".";
+import { Tabs, TabItem, TabsProps } from ".";
 import { act, Simulate } from "react-dom/test-utils";
+
+type TabsKeyboardEventTestCase = {
+    statement: string;
+    triggerEvent: () => void;
+    expectedOutcome: () => void;
+    props: TabsProps;
+};
 
 describe("Component: Tabs", () => {
     let container: HTMLDivElement = null;
+    const tabItems: string[] = ["First", "Second", "Third"];
+
+    const renderComponent = ({ children, ...props }: TabsProps = {}, items: string[] = []) => {
+        act(() => {
+            render(
+                <Tabs {...props}>
+                    {items.map((tab: string) => (
+                        <TabItem key={tab}>{tab}</TabItem>
+                    ))}
+                    {children}
+                </Tabs>,
+                container
+            );
+        });
+    };
 
     beforeEach(() => {
         container = document.createElement("div");
@@ -18,9 +40,7 @@ describe("Component: Tabs", () => {
     });
 
     it("Should render", () => {
-        act(() => {
-            render(<Tabs />, container);
-        });
+        renderComponent();
         expect(container).toBeDefined();
         expect(container.firstElementChild.tagName.toLowerCase()).toEqual("ul");
         expect(container.firstElementChild.classList.contains("rc")).toBeTruthy();
@@ -30,53 +50,76 @@ describe("Component: Tabs", () => {
     });
 
     it("Should render tab items correctly", () => {
-        act(() => {
-            render(
-                <Tabs>
-                    <TabItem>First</TabItem>
-                    <TabItem>Second</TabItem>
-                </Tabs>,
-                container
-            );
-        });
+        renderComponent({}, tabItems);
 
         const items = container.querySelectorAll("a");
 
-        expect(items).toHaveLength(2);
+        expect(items).toHaveLength(tabItems.length);
         expect(items.item(0).getAttribute("data-index-number")).toEqual("0");
         expect(items.item(1).getAttribute("data-index-number")).toEqual("1");
     });
 
     it("Should render non HTML elements", () => {
-        act(() => {
-            render(
-                <Tabs>
-                    <TabItem>First</TabItem>
-                    <TabItem>Second</TabItem>
-                    test123
-                </Tabs>,
-                container
-            );
-        });
-
+        renderComponent({ children: "test123" }, tabItems);
         expect(container.firstElementChild.textContent).toContain("test123");
     });
 
     it("Should fire onTabChange when an item is clicked", () => {
         const onTabChange: jest.Mock = jest.fn();
-
-        act(() => {
-            render(
-                <Tabs value={0} onTabChange={onTabChange}>
-                    <TabItem>First</TabItem>
-                    <TabItem>Second</TabItem>
-                </Tabs>,
-                container
-            );
-        });
+        renderComponent({ value: 0, onTabChange }, tabItems);
 
         act(() => Simulate.click(container.querySelectorAll("a").item(1)));
 
         expect(onTabChange).toBeCalledWith(1);
+    });
+
+    describe("Tabs keyboard event", () => {
+        const onTabChange: jest.Mock = jest.fn();
+        const onTabDelete: jest.Mock = jest.fn();
+        const testCases: Array<TabsKeyboardEventTestCase> = [
+            {
+                statement: "focus next element on arrow right button pressed",
+                triggerEvent: () => Simulate.keyDown(container.querySelector(".nav-tabs"), { key: "ArrowRight" }),
+                expectedOutcome: () => expect(document.activeElement.textContent).toBe(tabItems[2]),
+                props: { value: 1 },
+            },
+            {
+                statement: "focus previous element on arrow left button pressed",
+                triggerEvent: () => Simulate.keyDown(container.querySelector(".nav-tabs"), { key: "ArrowLeft" }),
+                expectedOutcome: () => expect(document.activeElement.textContent).toBe(tabItems[0]),
+                props: { value: 1 },
+            },
+            {
+                statement: "set tab item as active on spacebar pressed",
+                triggerEvent: () => Simulate.keyDown(container.querySelector(".nav-tabs"), { key: " " }),
+                expectedOutcome: () => expect(onTabChange).toBeCalled(),
+                props: { value: 1, onTabChange },
+            },
+            {
+                statement: "set tab item as active on enter pressed",
+                triggerEvent: () => Simulate.keyDown(container.querySelector(".nav-tabs"), { key: "Enter" }),
+                expectedOutcome: () => expect(onTabChange).toBeCalled(),
+                props: { value: 1, onTabChange },
+            },
+            {
+                statement: "fire onTabDelete on delete pressed",
+                triggerEvent: () => Simulate.keyDown(container.querySelector(".nav-tabs"), { key: "Delete" }),
+                expectedOutcome: () => expect(onTabDelete).toBeCalled(),
+                props: { value: 1, onTabDelete },
+            },
+            {
+                statement: "should set focus element as active on arrow right button pressed when autoSelectOnFocus is set",
+                triggerEvent: () => Simulate.keyDown(container.querySelector(".nav-tabs"), { key: "ArrowRight" }),
+                expectedOutcome: () => expect(onTabChange).toBeCalled(),
+                props: { value: 1, onTabChange, autoSelectOnFocus: true },
+            },
+        ];
+        testCases.forEach((testCase: TabsKeyboardEventTestCase) => {
+            it(testCase.statement, () => {
+                renderComponent(testCase.props, tabItems);
+                testCase.triggerEvent();
+                testCase.expectedOutcome();
+            });
+        });
     });
 });

--- a/lib/src/Tabs/Tabs.test.tsx
+++ b/lib/src/Tabs/Tabs.test.tsx
@@ -90,6 +90,18 @@ describe("Component: Tabs", () => {
                 props: { value: 1 },
             },
             {
+                statement: "focus first element on home button pressed",
+                triggerEvent: () => Simulate.keyDown(container.querySelector(".nav-tabs"), { key: "Home" }),
+                expectedOutcome: () => expect(document.activeElement.textContent).toBe(tabItems[0]),
+                props: { value: 1 },
+            },
+            {
+                statement: "focus first element on end button pressed",
+                triggerEvent: () => Simulate.keyDown(container.querySelector(".nav-tabs"), { key: "End" }),
+                expectedOutcome: () => expect(document.activeElement.textContent).toBe(tabItems[tabItems.length - 1]),
+                props: { value: 1 },
+            },
+            {
                 statement: "set tab item as active on spacebar pressed",
                 triggerEvent: () => Simulate.keyDown(container.querySelector(".nav-tabs"), { key: " " }),
                 expectedOutcome: () => expect(onTabChange).toBeCalled(),

--- a/lib/src/Tabs/Tabs.tsx
+++ b/lib/src/Tabs/Tabs.tsx
@@ -1,22 +1,62 @@
 import React from "react";
 import { TabItemProps } from "./TabItem";
 import classnames from "classnames";
+import { useCombinedRefs } from "../hooks/useCombinedRef";
 
 export type TabsProps = JSX.IntrinsicElements["ul"] & {
     /** Index of focsued tab */
     value?: number;
+    /** set focused index to active index on focus */
+    autoSelectOnFocus?: boolean;
     /** Callback on tab item changed */
     onTabChange?: (index: number) => void;
+    /** Callback on tab item when delete key is triggered */
+    onTabDelete?: (index: number) => void;
 };
 /** Tabs organize and allow navigation between groups of content that are related and at the same level of hierarchy. */
-export const Tabs: React.FC<TabsProps> = React.forwardRef(({ value, onTabChange, ...props }: TabsProps, ref: React.ForwardedRef<HTMLUListElement>) => {
+export const Tabs: React.FC<TabsProps> = React.forwardRef(({ value, onTabChange, autoSelectOnFocus, onTabDelete, ...props }: TabsProps, ref: React.ForwardedRef<HTMLUListElement>) => {
+    const tabsRef: React.MutableRefObject<HTMLUListElement> = useCombinedRefs(ref);
+    const [focusedIndex, setFocusedIndex] = React.useState<number>(value);
+
+    const navigateToTab = (target: HTMLAnchorElement, event: React.MouseEvent | React.KeyboardEvent) => {
+        const nextFocusedIndex: number = parseInt(target.dataset.indexNumber);
+        setFocusedIndex(nextFocusedIndex);
+        target.href?.endsWith("#") && event.preventDefault();
+        if (target.dataset.disabled !== "true") {
+            onTabChange && onTabChange(nextFocusedIndex);
+        }
+    };
     const onClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
-        event.currentTarget.href.endsWith("#") && event.preventDefault();
-        onTabChange && onTabChange(parseInt(event.currentTarget.dataset.indexNumber));
+        navigateToTab(event.currentTarget, event);
+    };
+
+    const onKeyDown = (event: React.KeyboardEvent<HTMLUListElement>) => {
+        const items: HTMLAnchorElement[] = Array.from(tabsRef.current.querySelectorAll(".nav-tabs > .rc.nav-item > .nav-link"));
+        switch (event.key) {
+            case "Enter":
+            case " ":
+                navigateToTab(event.target as HTMLAnchorElement, event);
+                break;
+            case "ArrowLeft":
+            case "ArrowRight":
+                const direction: number = event.key === "ArrowLeft" ? -1 : 1;
+                const nextFocusedIndex: number = focusedIndex + direction;
+                if (nextFocusedIndex >= 0 && nextFocusedIndex < items.length) {
+                    setFocusedIndex(nextFocusedIndex);
+                    items[nextFocusedIndex]?.focus();
+                    if (autoSelectOnFocus) {
+                        navigateToTab(items[nextFocusedIndex], event);
+                    }
+                }
+                break;
+            case "Delete":
+                onTabDelete && onTabDelete(focusedIndex);
+                break;
+        }
     };
 
     return (
-        <ul {...props} ref={ref} className={classnames("rc nav nav-tabs", props.className)} role={props.role || "tablist"}>
+        <ul {...props} ref={tabsRef} className={classnames("rc nav nav-tabs", props.className)} role={props.role || "tablist"} onKeyDown={onKeyDown}>
             {React.Children.map(props.children, (Child: React.ReactElement<TabItemProps>, index: number) => {
                 return React.isValidElement<React.FC<TabItemProps>>(Child)
                     ? React.cloneElement<any>(Child, {

--- a/lib/src/utils/keyboardHelper.ts
+++ b/lib/src/utils/keyboardHelper.ts
@@ -1,6 +1,8 @@
 export enum Key {
     ArrowDown = "ArrowDown",
     ArrowUp = "ArrowUp",
+    ArrowLeft = "ArrowLeft",
+    ArrowRight = "ArrowRight",
     Escape = "Escape",
     End = "End",
     Enter = "Enter",
@@ -9,6 +11,7 @@ export enum Key {
     PageUp = "PageUp",
     Space = " ",
     Tab = "Tab",
+    Delete = "Delete",
 }
 
 /**


### PR DESCRIPTION
- added keyboard support based on [W3C guidelines](https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-1/tabs.html)
- introduced new properties:
  - autoSelectOnFocus: set focused element to active by auto activation
  - onTabDelete: to allow user to do some actions on delete button press
- refactored playground component to use tab component