### PR TITLE
refactor(feedback-indicator): improve accessibility

### DIFF
--- a/docs/src/pages/docs/feedbackindicator.tsx
+++ b/docs/src/pages/docs/feedbackindicator.tsx
@@ -31,9 +31,13 @@ const FeedbackIndicatorPage: React.FC = () => {
             mainFile={importString}
             example={
                 <div className="w-100">
-                    <FeedbackIndicator type={controls.type} message={controls?.message} noBorder={controls.noBorder}>
-                        <Checkbox>A Checkbox</Checkbox>
-                        <RadioButton>A Radio button</RadioButton>
+                    <FeedbackIndicator id="indicator" type={controls.type as IndicatorType} message={controls?.message} noBorder={controls.noBorder as boolean}>
+                        <Checkbox aria-describedby="indicator" aria-invalid={(controls.type as IndicatorType) === "danger"}>
+                            A Checkbox
+                        </Checkbox>
+                        <RadioButton aria-describedby="indicator" aria-invalid={(controls.type as IndicatorType) === "danger"}>
+                            A Radio button
+                        </RadioButton>
                         <div className="px-3 pb-2">Some content 🦾</div>
                     </FeedbackIndicator>
                 </div>

--- a/lib/src/FeedbackIndicator/FeedbackIndicator.tsx
+++ b/lib/src/FeedbackIndicator/FeedbackIndicator.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import classnames from "classnames";
+import React from "react";
 import "./feedback-indicator.scss";
 
 export type IndicatorType = "danger" | "warning" | "success" | "none";
@@ -12,6 +12,8 @@ type FeedbackIndicatorProps = React.PropsWithChildren<{
     message?: React.ReactNode;
     /** Disable feedback indicator border */
     noBorder?: boolean;
+    /** The feedback indicator identifier. */
+    id?: string;
 }>;
 /** A helper component to display feedback for children content */
 export const FeedbackIndicator: React.FC<FeedbackIndicatorProps> = (props: FeedbackIndicatorProps) => {
@@ -41,7 +43,11 @@ export const FeedbackIndicator: React.FC<FeedbackIndicatorProps> = (props: Feedb
                 {React.cloneElement<any>(Child as any, {
                     className: classnames((Child.props as any).className, `rc-d feedback feedback-${indicatorValue}`, { "no-border": props.noBorder }, { "mb-0": props.message }),
                 })}
-                {props.type && <p className={classnames("rc-d feedback-message")}>{props.message}</p>}
+                {props.type && (
+                    <p className={classnames("rc-d feedback-message")} role="alert" id={props.id}>
+                        {props.message}
+                    </p>
+                )}
             </>
         ) : (
             Child


### PR DESCRIPTION
improve feedback indicator semantics based on the guide [here](https://www.w3.org/WAI/tutorials/forms/notifications/)

- add identifier prop to allow relevant input to reference the feedback message via `aria-describedby`