### PR TITLE
Update rollup.config.js

### DIFF
--- a/lib/rollup.config.js
+++ b/lib/rollup.config.js
@@ -8,7 +8,7 @@ import commonPkg from "../package.json";
 const components = require("./src/index.json");
 
 function injectCSS(css, uniqueId, isPrepend) {
-    if (!css || !document) {
+    if (!css || typeof document === 'undefined') {
         return;
     }
     


### PR DESCRIPTION
SSR environment doesn't have window context, therefore referring document explicitly would throw 'ReferenceError: document is not defined.'. Suggest to check by type instead. 